### PR TITLE
Include domain in labels instead of config file

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,6 +26,7 @@ services:
     - "traefik.enable=true"
     - "traefik.backend=microbot"
     - "traefik.frontend.rule=Host:microbot.example.com"
+    - "traefik.domain=microbot.example.com"
     - "traefik.docker.network=reverseproxy_default"
     networks:
     - "reverseproxy_default"


### PR DESCRIPTION
Is there a different way to enable different domains getting a letsencrypt cert?